### PR TITLE
fix capitalization in fn call

### DIFF
--- a/plotting/plotOnEgi.m
+++ b/plotting/plotOnEgi.m
@@ -75,7 +75,7 @@ elseif size(data,1) == 32
     nChan = 32;
 elseif size(data,1) == 7
     
-    data = expandAMatrixto128Channels(data);
+    data = expandAMatrixTo128Channels(data);
     tEpos = load('defaultFlatNet.mat');
     tEpos = [ tEpos.xy, zeros(128,1) ];
     


### PR DESCRIPTION
In plotOnEgi, I updated the call to my new function for plotting the 7-channel DSI-VR300 montage (line 78; one more letter needed to be capitalized).